### PR TITLE
Point documentation in Cargo.toml to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "LICENSE.md"
 edition = "2015"
 
 description = "A .DS_Store parser for Rust."
-documentation = "https://github.com/sinistersnare/ds_store"
+documentation = "https://docs.rs/ds_store/"
 repository = "https://github.com/sinistersnare/ds_store"
 homepage = "https://github.com/sinistersnare/ds_store"
 readme = "README.md"


### PR DESCRIPTION
This key should point to the documentation produced by running `cargo doc`, whether it's hosted by you or docs.rs.