### PR TITLE
Add `ptbL` and `ptbN` record types.

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -356,6 +356,14 @@ impl<'a> Block<'a> {
                     other => Err(Error::UnkonwnStructureType(other)),
                 }
             },
+            b"ptbL" => {
+                self.read_exact(b"ustr", "\"ptbL\" only takes ustr")?;
+                Ok(RecordValue::String(self.read_utf16()?))
+            },
+            b"ptbN" => {
+                self.read_exact(b"ustr", "\"ptbN\" only takes ustr")?;
+                Ok(RecordValue::String(self.read_utf16()?))
+            },
             other => Err(Error::UnkonwnStructureType(other)),
         }?;
         // should be impossible to hit error case,


### PR DESCRIPTION
`ptbL`: The original location of a file in Trash (`ustr`)
`ptbN`:  The original filename of a file (`ustr`) in case a date was appended onto the filename in the Trash directory.

I was planning on trying to help out with the TODOs but I realised quickly I was out of my depth so I'll leave it alone for now. For now these new record types allow this crate to work for my needs.